### PR TITLE
Add a window for tracking awards with history

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsWelcomeUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsWelcomeUI.lua
@@ -1,0 +1,176 @@
+require "ISUI/ISPanel"
+require "ISUI/ISButton"
+require "ISUI/ISScrollingListBox"
+
+-- Variable global para la ventana
+awardsWelcomeWindow = nil
+
+AwardsWelcomeUI = ISPanel:derive("AwardsWelcomeUI");
+
+function AwardsWelcomeUI:initialise()
+    ISPanel.initialise(self);
+    self:create();
+end
+
+function AwardsWelcomeUI:prerender()
+    ISPanel.prerender(self);
+    -- Título principal
+    self:drawText(getText("UI_welcomeawards"), 10, 10, 1, 1, 1, 1, UIFont.Medium);
+    -- Versión del mod
+    self:drawText(getText("UI_version") .. ": 1.0", 10, 40, 0.8, 0.8, 0.8, 1, UIFont.Small);
+    -- Instrucciones básicas
+    self:drawText(getText("UI_instructions"), 10, 70, 0.8, 0.8, 0.8, 1, UIFont.Small);
+end
+
+function AwardsWelcomeUI:create()
+    local btnWidth = 100
+    local btnHeight = 25
+
+    -- Lista de premios
+    self.awardsList = ISScrollingListBox:new(10, 100, self.width - 20, self.height - 140);
+    self.awardsList:initialise();
+    self.awardsList:instantiate();
+    self.awardsList.itemheight = 22;
+    self.awardsList.selected = 0;
+    self.awardsList.joypadParent = self;
+    self.awardsList.font = UIFont.NewSmall;
+    self.awardsList.doDrawItem = self.drawAwardItem;
+    self.awardsList:setOnMouseDownFunction(self, self.onAwardClick);
+    self:addChild(self.awardsList);
+
+    -- Botón de cerrar
+    self.closeButton = ISButton:new(
+        self:getWidth() - btnWidth - 10,
+        self:getHeight() - btnHeight - 10,
+        btnWidth,
+        btnHeight,
+        getText("UI_close"),
+        self,
+        AwardsWelcomeUI.onCloseClick
+    );
+    self.closeButton:initialise();
+    self.closeButton:instantiate();
+    self:addChild(self.closeButton);
+end
+
+-- Dibuja cada item de la lista
+function AwardsWelcomeUI:drawAwardItem(y, item, alt)
+    local a = 0.9;
+    self:drawRectBorder(0, y, self:getWidth(), self.itemheight - 1, a, self.borderColor.r, self.borderColor.g, self.borderColor.b);
+
+    if self.selected == item.index then
+        self:drawRect(0, y, self:getWidth(), self.itemheight - 1, 0.3, 0.7, 0.35, 0.15);
+    end
+
+    self:drawText(item.text, 10, y + 2, 1, 1, 1, a, self.font);
+
+    return y + self.itemheight;
+end
+
+function AwardsWelcomeUI:onAwardClick(item)
+    -- Puedes agregar alguna acción al hacer clic en un premio si lo deseas
+end
+
+function AwardsWelcomeUI:onCloseClick()
+    self:setVisible(false);
+    self:removeFromUIManager();
+end
+
+-- Agrega un mensaje a la lista de premios
+function AwardsWelcomeUI:addAwardMessage(message)
+    self.awardsList:addItem(message, {});
+    -- Hacer scroll hasta el último mensaje
+    self.awardsList.selected = self.awardsList:size();
+end
+
+function AwardsWelcomeUI:new(x, y, width, height)
+    local o = {};
+    o = ISPanel:new(x, y, width, height);
+    setmetatable(o, self);
+    self.__index = self;
+
+    o.backgroundColor = {r=0.1, g=0.1, b=0.1, a=0.9};
+    o.borderColor = {r=0.7, g=0.7, b=0.7, a=0.5};
+    o.moveWithMouse = true;
+    return o;
+end
+
+-- Función para crear la ventana
+function CreateWelcomeWindow()
+    if awardsWelcomeWindow then return end
+
+    local screenW = getCore():getScreenWidth()
+    local screenH = getCore():getScreenHeight()
+    local width = 400
+    local height = 300
+    local x = (screenW - width) / 2
+    local y = (screenH - height) / 2
+
+    awardsWelcomeWindow = AwardsWelcomeUI:new(x, y, width, height)
+    awardsWelcomeWindow:initialise();
+    awardsWelcomeWindow:addToUIManager();
+end
+
+-- HUD Button para abrir/cerrar la ventana de premios
+AwardsHUDButton = ISButton:derive("AwardsHUDButton")
+AwardsHUDButton.instance = nil
+
+function AwardsHUDButton:new(x, y, width, height)
+    local o = ISButton:new(x, y, width, height, "★", nil, function()
+        if awardsWelcomeWindow and awardsWelcomeWindow:isVisible() then
+            awardsWelcomeWindow:setVisible(false)
+            awardsWelcomeWindow:removeFromUIManager()
+        else
+            if not awardsWelcomeWindow then
+                CreateWelcomeWindow()
+            else
+                awardsWelcomeWindow:setVisible(true)
+                awardsWelcomeWindow:addToUIManager()
+            end
+        end
+    end)
+    setmetatable(o, self)
+    self.__index = self
+    o.backgroundColor = {r=0.1, g=0.1, b=0.1, a=0.8}
+    o.backgroundColorMouseOver = {r=0.3, g=0.3, b=0.3, a=0.8}
+    o.borderColor = {r=1, g=1, b=1, a=0.3}
+    return o
+end
+
+local function createHUDButton()
+    if AwardsHUDButton.instance then return end
+    local btnSize = 32
+    local x = getCore():getScreenWidth() - btnSize - 20
+    local y = 20
+
+    local btn = AwardsHUDButton:new(x, y, btnSize, btnSize)
+    btn:setAnchorLeft(false)
+    btn:setAnchorRight(true)
+    btn:setAnchorTop(true)
+    btn:setAnchorBottom(false)
+    btn.tooltip = getText("UI_awards_button_tooltip")
+    btn:initialise()
+    btn:addToUIManager()
+    AwardsHUDButton.instance = btn
+end
+
+-- Evento para mostrar la ventana al iniciar el juego
+local function OnGameStart()
+    -- Pequeño retraso para asegurar que todo esté cargado
+    Events.OnTick.Add(function()
+        if not awardsWelcomeWindow then
+            CreateWelcomeWindow()
+            Events.OnTick.Remove(this)
+        end
+    end)
+    createHUDButton()
+end
+
+Events.OnGameStart.Add(OnGameStart)
+
+-- Función global para agregar mensajes desde cualquier parte
+function AddAwardMessageToUI(message)
+    if awardsWelcomeWindow then
+        awardsWelcomeWindow:addAwardMessage(message)
+    end
+end

--- a/Contents/mods/ItemsAwards/media/lua/client/awards.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/awards.lua
@@ -2,96 +2,120 @@ Awards = Awards or {}
 Awards.Options = Awards.Options or {}
 
 local itemsAwards = {
-  {Item = "Base.BaseballBatNails", Number = 5, Count = 1}, -- Spiked Baseball Bat
-  {Item = "Base.FishingRodBreak", Number = 10, Count = 1}, -- Fishing Rod without Line
-  {Item = "Base.MetalBar", Number = 15, Count = 3}, -- Metal Bar
-  {Item = "Base.MetalPipe", Number = 20, Count = 3}, -- Metal Pipe
-  {Item = "Base.Katana", Number = 25, Count = 1}, -- Katana
-  {Item = "Base.Machete", Number = 30, Count = 1}, -- Machete
-  {Item = "Base.GardenFork", Number = 35, Count = 1}, -- Garden Fork
-  {Item = "Base.Revolver_Short", Number = 40, Count = 1}, -- M36 Revolver
-  {Item = "Base.AssaultRifle2", Number = 45, Count = 1}, -- M14 Rifle
-  {Item = "Base.AssaultRifle", Number = 50, Count = 1}, -- M16 Assault Rifle
-  {Item = "Base.DoubleBarrelShotgun", Number = 55, Count = 1}, -- Double Barrel Shotgun
-  {Item = "Base.Bullets38", Number = 60, Count = 2}, -- .38 Special Round
-  {Item = "Base.ShotgunShellsBox", Number = 65, Count = 1}, -- Box of Shotgun Shells
-  {Item = "Base.308Box", Number = 70, Count = 1}, -- Box of .308 Rounds
-  {Item = "Base.556Box", Number = 75, Count = 1}, -- Box of 5.56mm Rounds
-  {Item = "Base.LongJohns", Number = 80, Count = 1}, -- Long Johns
-  {Item = "Base.Jumper_DiamondPatternTINT", Number = 85, Count = 1}, -- Diamond-pattern Sweater
-  {Item = "Base.Jacket_Black", Number = 90, Count = 1}, -- Leather Jacket
-  {Item = "Base.Apron_Spiffos", Number = 95, Count = 1}, -- Spiffo's Server Apron
-  {Item = "Base.TrousersMesh_Leather", Number = 100, Count = 1}, -- Skinny Leather Trousers
-  {Item = "Base.SpiffoSuit", Number = 105, Count = 1}, -- Spiffo Suit
-  {Item = "Base.SpiffoTail", Number = 110, Count = 1}, -- Spiffo Suit Tail
-  {Item = "Base.BunnyTail", Number = 115, Count = 1}, -- Bunny Tail
-  {Item = "Base.Hat_HockeyMask", Number = 120, Count = 1}, -- Hockey Mask
-  {Item = "Base.Hat_BunnyEarsBlack", Number = 125, Count = 1}, -- Bunny Ears (Black)
-  {Item = "Base.Hat_BunnyEarsWhite", Number = 130, Count = 1}, -- Bunny Ears (White)
-  {Item = "Base.Hat_Jay", Number = 135, Count = 1}, -- Jay Chicken Hat
-  {Item = "Base.Hat_Spiffo", Number = 140, Count = 1}, -- Spiffo Suit Head
-  {Item = "Base.Bag_ALICEpack_Army", Number = 145, Count = 1}, -- Military Backpack
-  {Item = "Base.Bag_SurvivorBag", Number = 150, Count = 1}, -- Large Backpack
-  {Item = "Base.Bag_ALICEpack", Number = 155, Count = 1}, -- Large Backpack
-  {Item = "Base.WaterMugSpiffo", Number = 160, Count = 1}, -- Mug of Water
-  {Item = "Base.CarBatteryCharger", Number = 165, Count = 1}, -- Car Battery Charger
-  {Item = "Base.WoodAxe", Number = 170, Count = 1}, -- Wood Axe
-  {Item = "Base.BoxOfJars", Number = 175, Count = 1}, -- Box of Jars
-  {Item = "Base.CombinationPadlock", Number = 180, Count = 1}, -- Combination Padlock
-  {Item = "Base.Padlock", Number = 185, Count = 1}, -- Padlock
-  {Item = "Base.BurgerRecipe", Number = 190, Count = 1}, -- Burger
-  {Item = "Base.AlcoholBandage", Number = 195, Count = 1}, -- Sterilized Bandage
-  {Item = "Base.Comfrey", Number = 200, Count = 2}, -- Comfrey
-  {Item = "Base.Ginseng", Number = 205, Count = 1}, -- Ginseng
-  {Item = "Radio.RadioMag1", Number = 210, Count = 1}, -- Guerilla Radio Vol. 1
-  {Item = "Radio.RadioMag2", Number = 215, Count = 1}, -- Guerilla Radio Vol. 2
-  {Item = "Radio.RadioMag3", Number = 220, Count = 1}, -- Guerilla Radio Vol. 3
-  {Item = "Base.HottieZ", Number = 225, Count = 1}, -- HottieZ
-  {Item = "Base.EngineParts", Number = 230, Count = 1}, -- Spare Engine Parts
-  {Item = "Base.Glue", Number = 235, Count = 1}, -- Glue
-  {Item = "Base.Woodglue", Number = 240, Count = 1}, -- Wood Glue
-  {Item = "Base.Aluminum", Number = 245, Count = 1}, -- Aluminum
-  {Item = "Base.SheetMetal", Number = 250, Count = 1}, -- Metal Sheet
-  {Item = "Base.Pillow", Number = 255, Count = 1}, -- Pillow
-  {Item = "Base.PropaneTank", Number = 260, Count = 1}, -- Propane Tank
-  {Item = "Base.SmallSheetMetal", Number = 265, Count = 1}, -- Small Metal Sheet
-  {Item = "Radio.ElectricWire", Number = 270, Count = 1}, -- Electric Wire
-  {Item = "Base.SpiffoBig", Number = 275, Count = 1}, -- Big Spiffo
-  {Item = "Base.Spiffo", Number = 280, Count = 1}, -- Spiffo
-  {Item = "Base.VHS_Home", Number = 290, Count = 1}, -- VHS Home
+    {Item = "Base.BaseballBatNails", Number = 5, Count = 1}, -- Spiked Baseball Bat
+    {Item = "Base.FishingRodBreak", Number = 10, Count = 1}, -- Fishing Rod without Line
+    {Item = "Base.MetalBar", Number = 15, Count = 3}, -- Metal Bar
+    {Item = "Base.MetalPipe", Number = 20, Count = 3}, -- Metal Pipe
+    {Item = "Base.Katana", Number = 25, Count = 1}, -- Katana
+    {Item = "Base.Machete", Number = 30, Count = 1}, -- Machete
+    {Item = "Base.GardenFork", Number = 35, Count = 1}, -- Garden Fork
+    {Item = "Base.Revolver_Short", Number = 40, Count = 1}, -- M36 Revolver
+    {Item = "Base.AssaultRifle2", Number = 45, Count = 1}, -- M14 Rifle
+    {Item = "Base.AssaultRifle", Number = 50, Count = 1}, -- M16 Assault Rifle
+    {Item = "Base.DoubleBarrelShotgun", Number = 55, Count = 1}, -- Double Barrel Shotgun
+    {Item = "Base.Bullets38", Number = 60, Count = 2}, -- .38 Special Round
+    {Item = "Base.ShotgunShellsBox", Number = 65, Count = 1}, -- Box of Shotgun Shells
+    {Item = "Base.308Box", Number = 70, Count = 1}, -- Box of .308 Rounds
+    {Item = "Base.556Box", Number = 75, Count = 1}, -- Box of 5.56mm Rounds
+    {Item = "Base.LongJohns", Number = 80, Count = 1}, -- Long Johns
+    {Item = "Base.Jumper_DiamondPatternTINT", Number = 85, Count = 1}, -- Diamond-pattern Sweater
+    {Item = "Base.Jacket_Black", Number = 90, Count = 1}, -- Leather Jacket
+    {Item = "Base.Apron_Spiffos", Number = 95, Count = 1}, -- Spiffo's Server Apron
+    {Item = "Base.TrousersMesh_Leather", Number = 100, Count = 1}, -- Skinny Leather Trousers
+    {Item = "Base.SpiffoSuit", Number = 105, Count = 1}, -- Spiffo Suit
+    {Item = "Base.SpiffoTail", Number = 110, Count = 1}, -- Spiffo Suit Tail
+    {Item = "Base.BunnyTail", Number = 115, Count = 1}, -- Bunny Tail
+    {Item = "Base.Hat_HockeyMask", Number = 120, Count = 1}, -- Hockey Mask
+    {Item = "Base.Hat_BunnyEarsBlack", Number = 125, Count = 1}, -- Bunny Ears (Black)
+    {Item = "Base.Hat_BunnyEarsWhite", Number = 130, Count = 1}, -- Bunny Ears (White)
+    {Item = "Base.Hat_Jay", Number = 135, Count = 1}, -- Jay Chicken Hat
+    {Item = "Base.Hat_Spiffo", Number = 140, Count = 1}, -- Spiffo Suit Head
+    {Item = "Base.Bag_ALICEpack_Army", Number = 145, Count = 1}, -- Military Backpack
+    {Item = "Base.Bag_SurvivorBag", Number = 150, Count = 1}, -- Large Backpack
+    {Item = "Base.Bag_ALICEpack", Number = 155, Count = 1}, -- Large Backpack
+    {Item = "Base.WaterMugSpiffo", Number = 160, Count = 1}, -- Mug of Water
+    {Item = "Base.CarBatteryCharger", Number = 165, Count = 1}, -- Car Battery Charger
+    {Item = "Base.WoodAxe", Number = 170, Count = 1}, -- Wood Axe
+    {Item = "Base.BoxOfJars", Number = 175, Count = 1}, -- Box of Jars
+    {Item = "Base.CombinationPadlock", Number = 180, Count = 1}, -- Combination Padlock
+    {Item = "Base.Padlock", Number = 185, Count = 1}, -- Padlock
+    {Item = "Base.BurgerRecipe", Number = 190, Count = 1}, -- Burger
+    {Item = "Base.AlcoholBandage", Number = 195, Count = 1}, -- Sterilized Bandage
+    {Item = "Base.Comfrey", Number = 200, Count = 2}, -- Comfrey
+    {Item = "Base.Ginseng", Number = 205, Count = 1}, -- Ginseng
+    {Item = "Radio.RadioMag1", Number = 210, Count = 1}, -- Guerilla Radio Vol. 1
+    {Item = "Radio.RadioMag2", Number = 215, Count = 1}, -- Guerilla Radio Vol. 2
+    {Item = "Radio.RadioMag3", Number = 220, Count = 1}, -- Guerilla Radio Vol. 3
+    {Item = "Base.HottieZ", Number = 225, Count = 1}, -- HottieZ
+    {Item = "Base.EngineParts", Number = 230, Count = 1}, -- Spare Engine Parts
+    {Item = "Base.Glue", Number = 235, Count = 1}, -- Glue
+    {Item = "Base.Woodglue", Number = 240, Count = 1}, -- Wood Glue
+    {Item = "Base.Aluminum", Number = 245, Count = 1}, -- Aluminum
+    {Item = "Base.SheetMetal", Number = 250, Count = 1}, -- Metal Sheet
+    {Item = "Base.Pillow", Number = 255, Count = 1}, -- Pillow
+    {Item = "Base.PropaneTank", Number = 260, Count = 1}, -- Propane Tank
+    {Item = "Base.SmallSheetMetal", Number = 265, Count = 1}, -- Small Metal Sheet
+    {Item = "Radio.ElectricWire", Number = 270, Count = 1}, -- Electric Wire
+    {Item = "Base.SpiffoBig", Number = 275, Count = 1}, -- Big Spiffo
+    {Item = "Base.Spiffo", Number = 280, Count = 1}, -- Spiffo
+    {Item = "Base.VHS_Home", Number = 290, Count = 1}, -- VHS Home
 }
 
+-- Función principal que maneja la muerte de zombies
 local function ZombKilled(zombie)
-  local attacker = zombie:getAttackedBy()
-
-  if attacker == nil or not instanceof(attacker, "IsoPlayer") or attacker:getVehicle() ~= nil then
-    return
-  end
-
-  local number = ZombRandBetween(1, 501)
-  local won = false
-
-  for key, value in pairs(itemsAwards) do
-    if (number == value.Number) then
-      local itemName = getItemNameFromFullType(value.Item)
-      zombie:getInventory():AddItems(value.Item, value.Count)
-      if Awards.Options.showMessageInChat then
-        attacker:Say(string.format(getText("IGUI_WonItem"), itemName, value.Count))
-      else
-        attacker:setHaloNote(string.format(getText("IGUI_WonItem"), itemName, value.Count))
-      end
-      won = true
-      break
+    -- Verificar si hay un atacante válido
+    local attacker = zombie:getAttackedBy()
+    if attacker == nil or not instanceof(attacker, "IsoPlayer") or attacker:getVehicle() ~= nil then
+        return
     end
-  end
 
-  if not won and Awards.Options.showNumberWhenLosing then
-    if Awards.Options.showMessageInChat then
-      attacker:Say(string.format(getText("IGUI_LoseItem"), number))
-    else
-      attacker:setHaloNote(string.format(getText("IGUI_LoseItem"), number), 255, 0, 0, 300)
+    -- Generar número aleatorio para premios
+    local number = ZombRandBetween(1, 501)
+    local won = false
+
+    -- Verificar si ganó algún premio
+    for key, value in pairs(itemsAwards) do
+        if (number == value.Number) then
+            -- Obtener el nombre del item y agregarlo al inventario
+            local itemName = getItemNameFromFullType(value.Item)
+            zombie:getInventory():AddItems(value.Item, value.Count)
+
+            -- Mostrar mensaje al jugador
+            local message = string.format(getText("IGUI_WonItem"), itemName, value.Count)
+            if Awards.Options.showMessageInChat then
+                attacker:Say(message)
+            else
+                attacker:setHaloNote(message)
+            end
+
+            -- Agregar mensaje al log y a la UI
+            local awardMessage = itemName .. " x" .. value.Count
+            
+            -- Agregar al log personalizado si existe la función
+            if AddAwardsLogMessage then
+                AddAwardsLogMessage(awardMessage)
+            end
+
+            -- Agregar a la UI si existe la función
+            if AddAwardMessageToUI then
+                AddAwardMessageToUI(awardMessage)
+            end
+
+            won = true
+            break
+        end
     end
-  end
+
+    -- Mostrar mensaje de pérdida si está configurado
+    if not won and Awards.Options.showNumberWhenLosing then
+        local message = string.format(getText("IGUI_LoseItem"), number)
+        if Awards.Options.showMessageInChat then
+            attacker:Say(message)
+        else
+            attacker:setHaloNote(message, 255, 0, 0, 300)
+        end
+    end
 end
 
+-- Registrar el evento
 Events.OnZombieDead.Add(ZombKilled)

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/AR/UI_AR.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/AR/UI_AR.txt
@@ -1,4 +1,10 @@
 UI_AR = {
     UI_Awards_showNumberWhenLosing = "Mostrar dado al perder",
     UI_Awards_showMessageInChat = "Mostrar mensaje en el chat"
+    UI_welcomeawards = "¡Bienvenido a Items & Awards!",
+    UI_version = "Versión",
+    UI_instructions = "Aquí esta el registro de lo ganado.",
+    UI_close = "Cerrar",
+    UI_pressF10 = "Presiona F10 para abrir/cerrar esta ventana",
+    UI_awards_button_tooltip = "Abrir/Cerrar Ventana de Premios",
 }

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/EN/IG_UI_EN.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/EN/IG_UI_EN.txt
@@ -1,4 +1,10 @@
 IGUI_EN = {
   IGUI_WonItem = "[Items Awards]: You have won: %s. Amount: %d",
   IGUI_LoseItem = "Your number was: %of. Keep trying!",
+  UI_welcomeawards = "Welcome to Items & Awards!",
+  UI_version = "Version",
+  UI_instructions = "Here is the record of what was won.",
+  UI_close = "Close",
+  UI_pressF10 = "Press F10 to open/close this window",
+  UI_awards_button_tooltip = "Open/Close Awards Window",
 }

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/ES/UI_ES.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/ES/UI_ES.txt
@@ -1,4 +1,10 @@
 UI_ES = {
     UI_Awards_showNumberWhenLosing = "Mostrar dado al perder",
     UI_Awards_showMessageInChat = "Mostrar mensaje en el chat"
+    UI_welcomeawards = "¡Bienvenido a Items & Awards!",
+    UI_version = "Versión",
+    UI_instructions = "Aquí esta el registro de lo ganado.",
+    UI_close = "Cerrar",
+    UI_pressF10 = "Presiona F10 para abrir/cerrar esta ventana",
+    UI_awards_button_tooltip = "Abrir/Cerrar Ventana de Premios",
 }


### PR DESCRIPTION
Se sumo una ventana emergente ingame con botón abrir/cerrar arriba a la derecha que lleva el historial de los premios ganados a medida que se obtienen. Faltan mejorar títulos, personalizar el botón. Importante: El historial quedara activo hasta tanto el usuario cierre el juego. Una vez que reingrese aparecerá sin contenido.

An in-game pop-up window has been added with an open/close button at the top right that displays the history of prizes earned as they are obtained. Titles need to be improved and the button customized. Important: The history will remain active until the user closes the game. Once the user re-enters the game, it will appear empty.

https://youtu.be/UADchVSLuCg