### PR TITLE
chore(UI/awardsUI) Remove winning item by selecting it

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -248,8 +248,6 @@ local function OnGameStart()
     createHUDButton()
 end
 
-Events.OnGameStart.Add(OnGameStart)
-
 function AddAwardMessageToUI(_item, _message)
     if awardsWelcomeWindow then
         awardsWelcomeWindow:addAwardMessage(_item, _message)
@@ -261,3 +259,5 @@ function AddLoserMessageToUI(message)
         awardsWelcomeWindow:addLoserMessage(message)
     end
 end
+
+Events.OnGameStart.Add(OnGameStart)

--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -30,6 +30,7 @@ function AwardsWelcomeUI:create()
     self.awardsList.joypadParent = self
     self.awardsList.font = UIFont.NewSmall
     self.awardsList.doDrawItem = self.drawAwardItem
+    self.awardsList:setOnMouseDownFunction(self, self.onAwardClick)
     self:addChild(self.awardsList)
 
     self.losersList = ISScrollingListBox:new(10, self.awardsList:getY() + self.awardsList:getHeight() + 10, self.width - 20, 110)
@@ -138,6 +139,13 @@ function AwardsWelcomeUI:addAwardMessage(_item, _message)
 
     while self.awardsList:size() > limit do
         self.awardsList:removeItemByIndex(self.awardsList:size())
+    end
+end
+
+function AwardsWelcomeUI:onAwardClick()
+    local selectedIndex = self.awardsList.selected
+    if selectedIndex and selectedIndex > 0 then
+        self.awardsList:removeItemByIndex(selectedIndex)
     end
 end
 

--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -30,7 +30,7 @@ function AwardsWelcomeUI:create()
     self.awardsList.joypadParent = self
     self.awardsList.font = UIFont.NewSmall
     self.awardsList.doDrawItem = self.drawAwardItem
-    self.awardsList:setOnMouseDownFunction(self, self.onAwardClick)
+    self.awardsList:setOnMouseDoubleClick(self, self.onAwardDoubleClick)
     self:addChild(self.awardsList)
 
     self.losersList = ISScrollingListBox:new(10, self.awardsList:getY() + self.awardsList:getHeight() + 10, self.width - 20, 110)
@@ -142,7 +142,7 @@ function AwardsWelcomeUI:addAwardMessage(_item, _message)
     end
 end
 
-function AwardsWelcomeUI:onAwardClick()
+function AwardsWelcomeUI:onAwardDoubleClick()
     local selectedIndex = self.awardsList.selected
     if selectedIndex and selectedIndex > 0 then
         self.awardsList:removeItemByIndex(selectedIndex)


### PR DESCRIPTION
- A feature has been added so that when an item is selected from the winners list, it is deleted. However, it doesn't give the item to the player, nor does it delete it when the player takes it. It's simply a manual deletion of the log.
- We move the event to the end of the document.