### PR TITLE
Fix syntax errors in translation files

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/AR/UI_AR.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/AR/UI_AR.txt
@@ -1,6 +1,6 @@
 UI_AR = {
     UI_Awards_showNumberWhenLosing = "Mostrar dado al perder",
-    UI_Awards_showMessageInChat = "Mostrar mensaje en el chat"
+    UI_Awards_showMessageInChat = "Mostrar mensaje en el chat",
     UI_welcomeawards = "¡Bienvenido a Items Awards!",
     UI_version = "Versión",
     UI_instructions = "Aquí esta el registro de lo ganado.  El mismo se borra si te desconectas.",

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/ES/UI_ES.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/ES/UI_ES.txt
@@ -1,6 +1,6 @@
 UI_ES = {
     UI_Awards_showNumberWhenLosing = "Mostrar dado al perder",
-    UI_Awards_showMessageInChat = "Mostrar mensaje en el chat"
+    UI_Awards_showMessageInChat = "Mostrar mensaje en el chat",
     UI_welcomeawards = "¡Bienvenido a Items Awards!",
     UI_version = "Versión",
     UI_instructions = "Aquí esta el registro de lo ganado.  El mismo se borra si te desconectas.",


### PR DESCRIPTION
Description: Syntax errors in the `AR` and `ES` translation files have been corrected. Commas were missing after the `UI_Awards_showMessageInChat` entry, which could cause parsing errors when loading the translations.