### PR TITLE
fix: remove duplicate string.format call in awards.lua

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/client/awards.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/awards.lua
@@ -52,13 +52,13 @@ local function ZombKilled(zombie)
             else
 
                 if Awards.Options.showMessageInChat then
-                    attacker:Say(string.format(string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills)))
+                    attacker:Say(string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills))
                 else
                     attacker:setHaloNote(string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills), 255, 0, 0, 300)
                 end
 
                 if AddLoserMessageToUI then
-                    AddLoserMessageToUI(string.format(string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills)))
+                    AddLoserMessageToUI(string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills))
                 end
 
             end


### PR DESCRIPTION
- The string.format was being used twice, so one of them is removed.
- Se estaba utilizando 2 veces el string.format, asi que se procede a eliminar uno de ellos.