### PR TITLE
refactor: split ZombKilled into focused helper functions

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/client/awards.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/awards.lua
@@ -13,75 +13,68 @@ local function awardsSendMessage(player, message, r, g, b, duration)
     end
 end
 
-local function ZombKilled(zombie)
-
+local function isValidAttacker(zombie)
     local attacker = zombie:getAttackedBy()
+    if attacker == nil then return nil end
+    if not instanceof(attacker, "IsoPlayer") then return nil end
+    if attacker:getVehicle() ~= nil then return nil end
+    return attacker
+end
 
-    if attacker == nil or not instanceof(attacker, "IsoPlayer") or attacker:getVehicle() ~= nil then
-        return
+local function tryGiveAward(attacker, zombie, number)
+    local countZombieKill = attacker:getZombieKills() + 1
+
+    for _, value in pairs(itemsAwards) do
+        if number ~= value.Number then
+            goto continue
+        end
+
+        local itemName = getItemNameFromFullType(value.Item)
+
+        if countZombieKill < value.zkills then
+            local message = string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills)
+            awardsSendMessage(attacker, message, 255, 0, 0, 300)
+            if AddLoserMessageToUI then AddLoserMessageToUI(message) end
+            return true
+        end
+
+        if value.onZombie then
+            zombie:getInventory():AddItems(value.Item, value.Count)
+        else
+            attacker:getInventory():AddItems(value.Item, value.Count)
+        end
+
+        local message = string.format(getText("IGUI_WonItem"), itemName, value.Count)
+        awardsSendMessage(attacker, message, 255, 255, 255, 300)
+
+        local awardMessage = string.format(getText("UI_awardMessage"), itemName, value.Count)
+        if AddAwardsLogMessage then AddAwardsLogMessage(awardMessage) end
+        if AddAwardMessageToUI then AddAwardMessageToUI(value.Item, awardMessage) end
+
+        return true
+
+        ::continue::
     end
+
+    return false
+end
+
+local function handleNoWin(attacker, number)
+    if not Awards.Options.showNumberWhenLosing then return end
+    local message = string.format(getText("IGUI_LoseItem"), number)
+    awardsSendMessage(attacker, message, 255, 0, 0, 300)
+    if AddLoserMessageToUI then AddLoserMessageToUI(message) end
+end
+
+local function ZombKilled(zombie)
+    local attacker = isValidAttacker(zombie)
+    if not attacker then return end
 
     local number = ZombRandBetween(1, 101)
-    local countZombieKill = attacker:getZombieKills() + 1
-    local won = false
+    local won = tryGiveAward(attacker, zombie, number)
 
-    for key, value in pairs(itemsAwards) do
-
-        if (number == value.Number) then
-
-            if (countZombieKill >= value.zkills) then
-
-                local itemName = getItemNameFromFullType(value.Item)
-
-                if value.onZombie then
-                    zombie:getInventory():AddItems(value.Item, value.Count)
-                else
-                    attacker:getInventory():AddItems(value.Item, value.Count)
-                end
-
-                local message = string.format(getText("IGUI_WonItem"), itemName, value.Count)
-
-                awardsSendMessage(attacker, message, 255, 255, 255, 300)
-
-                local awardMessage = string.format(getText("UI_awardMessage"), itemName, value.Count)
-
-                if AddAwardsLogMessage then
-                    AddAwardsLogMessage(awardMessage)
-                end
-
-                if AddAwardMessageToUI then
-                    AddAwardMessageToUI(value.Item, awardMessage)
-                end
-
-            else
-
-                awardsSendMessage(attacker, string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills), 255, 0, 0, 300)
-
-                if AddLoserMessageToUI then
-                    AddLoserMessageToUI(string.format(getText("IGUI_YouNeedMoreKills"), number, value.zkills))
-                end
-
-            end
-
-            won = true
-            break
-        end
-    end
-
-    if (not won) then
-
-        local message = string.format(getText("IGUI_LoseItem"), number)
-
-        if (Awards.Options.showNumberWhenLosing) then
-
-            awardsSendMessage(attacker, message, 255, 0, 0, 300)
-
-        end
-
-        if AddLoserMessageToUI then
-            AddLoserMessageToUI(message)
-        end
-
+    if not won then
+        handleNoWin(attacker, number)
     end
 end
 


### PR DESCRIPTION
ZombKilled was handling too many responsibilities: attacker validation, random number generation, award iteration, item delivery, and message dispatch. Split into three focused local functions: isValidAttacker, tryGiveAward, and handleNoWin. ZombKilled now acts as a clean orchestrator.

ZombKilled tenía demasiadas responsabilidades: validación del atacante, generación del número aleatorio, iteración de premios, entrega de ítems y despacho de mensajes. Se divide en tres funciones locales enfocadas: isValidAttacker, tryGiveAward y handleNoWin. ZombKilled queda como un orquestador limpio.