### PR TITLE
fix: properly deregister OnTick event after window creation

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -219,18 +219,6 @@ local function createHUDButton()
     AwardsHUDButton.instance = btn
 end
 
-local function OnGameStart()
-
-    Events.OnTick.Add(function()
-        if not awardsWelcomeWindow then
-            CreateWelcomeWindow()
-            Events.OnTick.Remove(this)
-        end
-    end)
-
-    createHUDButton()
-end
-
 function AddAwardMessageToUI(_item, _message)
     if AwardsWelcomeUI.instance then
         AwardsWelcomeUI.instance:addAwardMessage(_item, _message)
@@ -241,6 +229,18 @@ function AddLoserMessageToUI(_message)
     if AwardsWelcomeUI.instance then
         AwardsWelcomeUI.instance:addLoserMessage(_message)
     end
+end
+
+local function OnGameStart()
+    local onTick
+    onTick = function()
+        if not AwardsWelcomeUI.instance then
+            CreateWelcomeWindow()
+        end
+        Events.OnTick.Remove(onTick)
+    end
+    Events.OnTick.Add(onTick)
+    createHUDButton()
 end
 
 Events.OnGameStart.Add(OnGameStart)


### PR DESCRIPTION
Fix: properly deregister OnTick event after window creation

The OnTick callback in OnGameStart was calling Events.OnTick.Remove(this), but 'this' is undefined in that context. The callback was never deregistered, running on every tick for the entire game session. Fixed by assigning the function to a local variable before registering it, so it can reference itself correctly when removing.

El callback de OnTick en OnGameStart llamaba a Events.OnTick.Remove(this), pero 'this' no está definido en ese contexto. El callback nunca se desregistraba, ejecutándose en cada tick durante toda la sesión de juego. Se corrige asignando la función a una variable local antes de registrarla, para que pueda referenciarse a sí misma correctamente al momento de removerse.