### PR TITLE
feat: persist and restore HUD button position using player moddata

### DIFF
--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -2,9 +2,8 @@ require "ISUI/ISPanel"
 require "ISUI/ISButton"
 require "ISUI/ISScrollingListBox"
 
-AwardsWelcomeUI.instance = nil
-
 AwardsWelcomeUI = ISPanel:derive("AwardsWelcomeUI")
+AwardsWelcomeUI.instance = nil
 
 function AwardsWelcomeUI:initialise()
     ISPanel.initialise(self)

--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -175,6 +175,33 @@ end
 AwardsHUDButton = ISButton:derive("AwardsHUDButton")
 AwardsHUDButton.instance = nil
 
+function AwardsHUDButton:onMouseDown(x, y)
+    self.dragging = true
+    self.dragX = x
+    self.dragY = y
+end
+
+function AwardsHUDButton:onMouseMove(dx, dy)
+    if not self.dragging then return end
+    local newX = self:getX() + dx
+    local newY = self:getY() + dy
+    self:setX(newX)
+    self:setY(newY)
+end
+
+function AwardsHUDButton:onMouseUp(x, y)
+    if not self.dragging then return end
+    self.dragging = false
+
+    local player = getSpecificPlayer(0)
+    if player then
+        local modData = player:getModData()
+        modData.AwardsButtonX = self:getX()
+        modData.AwardsButtonY = self:getY()
+        player:save()
+    end
+end
+
 function AwardsHUDButton:new(x, y, width, height)
 
     local o = ISButton:new(x, y, width, height, "", nil, function()
@@ -204,8 +231,18 @@ end
 local function createHUDButton()
     if AwardsHUDButton.instance then return end
     local btnSize = 32
+
     local x = getCore():getScreenWidth() - 50
     local y = 600
+
+    local player = getSpecificPlayer(0)
+    if player then
+        local modData = player:getModData()
+        if modData.AwardsButtonX and modData.AwardsButtonY then
+            x = modData.AwardsButtonX
+            y = modData.AwardsButtonY
+        end
+    end
 
     local btn = AwardsHUDButton:new(x, y, btnSize, btnSize)
     btn:setAnchorLeft(false)


### PR DESCRIPTION
Feat: persist and restore HUD button position using player moddata

The HUD button position was hardcoded and couldn't be moved by the player. Added drag support to AwardsHUDButton by overriding onMouseDown, onMouseMove and onMouseUp. Position is saved to the player's ModData on every drag end
and restored on game start. Also fixes a pre-existing issue where AwardsWelcomeUI.instance was set before AwardsWelcomeUI was defined.

La posición del botón HUD estaba hardcodeada y el jugador no podía moverlo. Se agrega soporte de arrastre a AwardsHUDButton sobreescribiendo onMouseDown, onMouseMove y onMouseUp. La posición se guarda en el ModData del jugador al soltar el botón y se restaura al iniciar la partida. También se corrige un problema preexistente donde AwardsWelcomeUI.instance se asignaba antes de que AwardsWelcomeUI estuviera definido.