### PR TITLE
feat: notify player when awards data file is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+itemsAwardsData.lua

--- a/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/UI/awardsUI.lua
@@ -268,6 +268,13 @@ function AddLoserMessageToUI(_message)
 end
 
 local function OnGameStart()
+    if not Awards.dataFileLoaded then
+        local player = getSpecificPlayer(0)
+        if player then
+            player:Say(getText("IGUI_Awards_MissingDataFile"))
+        end
+    end
+
     local onTick
     onTick = function()
         if not AwardsWelcomeUI.instance then

--- a/Contents/mods/ItemsAwards/media/lua/client/awards.lua
+++ b/Contents/mods/ItemsAwards/media/lua/client/awards.lua
@@ -1,9 +1,18 @@
 Awards = Awards or {}
 Awards.Options = Awards.Options or {}
 
-local itemsAwards = {
-    {Item = "Base.CopperCoin", Number = 50, Count = 1, zkills = 1, onZombie = false}, -- Copper Coin
+local itemsAwardsDefault = {
+    { Item = "Base.Money", Number = 50, Count = 1, zkills = 1, onZombie = false },
 }
+
+local ok, data = pcall(require, "itemsAwardsData")
+local itemsAwards = (ok and type(data) == "table") and data or itemsAwardsDefault
+
+Awards.dataFileLoaded = ok
+
+if not ok then
+    print("[ItemsAwards] itemsAwardsData.lua not found, using default awards table.")
+end
 
 local function awardsSendMessage(player, message, r, g, b, duration)
     if Awards.Options.showMessageInChat then

--- a/Contents/mods/ItemsAwards/media/lua/client/itemsAwardsData.lua.example
+++ b/Contents/mods/ItemsAwards/media/lua/client/itemsAwardsData.lua.example
@@ -1,0 +1,24 @@
+-- ============================================================
+--  Items Awards - Server Configuration File
+-- ============================================================
+--  INSTRUCTIONS:
+--  1. Copy this file and rename it to: itemsAwardsData.lua
+--  2. Edit the list below with the rewards you want.
+--  3. Do NOT rename or modify this .example file.
+--
+--  Each entry represents one possible reward:
+--
+--  Item     (string)  : Full item type. Example: "Base.Axe"
+--  Number   (number)  : The lucky number (1-100) that triggers this reward.
+--                       Each number can only appear once.
+--  Count    (number)  : How many items the player receives.
+--  zkills   (number)  : Minimum zombie kills required to be eligible.
+--  onZombie (boolean) : If true, the item is placed on the zombie's body.
+--                       If false, it goes directly into the player's inventory.
+-- ============================================================
+
+return {
+    { Item = "Base.Money", Number = 50, Count = 1, zkills = 1, onZombie = false },
+    { Item = "Base.CopperCoin", Number = 50, Count = 1, zkills = 1,  onZombie = false },
+    { Item = "Base.Axe",        Number = 75, Count = 1, zkills = 10, onZombie = true  },
+}

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/AR/IG_UI_AR.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/AR/IG_UI_AR.txt
@@ -2,4 +2,5 @@ IGUI_AR = {
     IGUI_WonItem = "[Items Awards]: Has ganado: %s. Cantidad: %d",
     IGUI_LoseItem = "[Items Awards]: Tu número fue: %d. ¡Sigue intentando!",
     IGUI_YouNeedMoreKills = "[Items Awards]: Ganaste con %d, pero el premio requiere mas kills: %d",
+    IGUI_Awards_MissingDataFile = "[ItemsAwards] Fichero de configuración no encontrado. Por favor, pedile al administrador del servidor que cree itemsAwardsData.lua a partir del ejemplo incluido.",
 }

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/EN/IG_UI_EN.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/EN/IG_UI_EN.txt
@@ -2,4 +2,5 @@ IGUI_EN = {
     IGUI_WonItem = "[Items Awards]: You have won: %s. Amount: %d",
     IGUI_LoseItem = "[Items Awards]: Your number was: %d. Keep trying!",
     IGUI_YouNeedMoreKills = "[Items Awards]: You won with %d, but the prize requires more kills: %d",
+    IGUI_Awards_MissingDataFile = "[ItemsAwards] Configuration file missing. Please ask the server admin to create itemsAwardsData.lua from the provided example.",
 }

--- a/Contents/mods/ItemsAwards/media/lua/shared/Translate/ES/IG_UI_ES.txt
+++ b/Contents/mods/ItemsAwards/media/lua/shared/Translate/ES/IG_UI_ES.txt
@@ -2,4 +2,5 @@ IGUI_ES = {
     IGUI_WonItem = "[Items Awards]: Has ganado: %s. Cantidad: %d",
     IGUI_LoseItem = "[Items Awards]: Tu número fue: %d. ¡Sigue intentando!",
     IGUI_YouNeedMoreKills = "[Items Awards]: Ganaste con %d, pero el premio requiere mas kills: %d",
+    IGUI_Awards_MissingDataFile = "[ItemsAwards] Fichero de configuración no encontrado. Por favor, pedile al administrador del servidor que cree itemsAwardsData.lua a partir del ejemplo incluido.",
 }


### PR DESCRIPTION
When itemsAwardsData.lua is not found, a localized warning message is shown to the player once the game world is loaded, so the server admin is aware the configuration file needs to be created. Added the missing key to all three translation files (EN, ES, AR).

Cuando itemsAwardsData.lua no se encuentra, se muestra un mensaje de aviso localizado al jugador una vez que el mundo está cargado, para que el administrador del servidor sepa que debe crear el fichero de configuración. Se agrega la clave faltante en los tres ficheros de traducción (EN, ES, AR).